### PR TITLE
Introduce node v4.2.1 "Argon" support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER = docker
-TAGS = v0.10.x v0.12.x
+TAGS = v0.10.x v0.12.x v4.2.x
 
 all: release
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Node.js on Docker.
 
 ## Available Tags
 
-* `latest`: Currently Node.js v0.12.7
+* `latest`: Currently Node.js v4.2.1
+* `v4.2.x`: Node.js v4.2.1
 * `v0.12.x`: Node.js v0.12.7
 * `v0.10.x`: Node.js v0.10.38
 

--- a/v4.2.x/Dockerfile
+++ b/v4.2.x/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/aptible/debian:wheezy
+
+WORKDIR /tmp
+RUN wget -q http://nodejs.org/dist/v4.2.1/node-v4.2.1-linux-x64.tar.gz && \
+    tar xzf node-v4.2.1* && cd node-v4.2.1* && \
+    mv bin/* /usr/local/bin/ && \
+    mv lib/* /usr/local/lib/ && \
+    mv include/* /usr/local/include/ && \
+    cd .. && rm -rf node-v4.2.1*
+WORKDIR /
+
+ADD test /tmp/test
+RUN bats /tmp/test

--- a/v4.2.x/test/nodejs.bats
+++ b/v4.2.x/test/nodejs.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "It should use Node v4.2.1" {
+  node -v | grep 4.2.1
+}
+
+@test "It should install npm" {
+  which npm
+}


### PR DESCRIPTION
[Argon](https://nodejs.org/en/blog/release/v4.2.0/) is the first LTS release for Node 4, which means its should be favored instead of earlier (4.0.x, 4.1.x) versions.
