### PR TITLE
chore: update node 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Node.js on Docker.
 
 ## Available Tags
 
-* `latest`: Currently Node.js v4.2.4
-* `v4.2.x`: Node.js v4.2.4
+* `latest`: Currently Node.js v4.2.6
+* `v4.2.x`: Node.js v4.2.6
 * `v0.12.x`: Node.js v0.12.9
 * `v0.10.x`: Node.js v0.10.41
 

--- a/v4.2.x/Dockerfile
+++ b/v4.2.x/Dockerfile
@@ -1,12 +1,12 @@
 FROM quay.io/aptible/debian:wheezy
 
 WORKDIR /tmp
-RUN wget -q http://nodejs.org/dist/v4.2.4/node-v4.2.4-linux-x64.tar.gz && \
-    tar xzf node-v4.2.4* && cd node-v4.2.4* && \
+RUN wget -q http://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-x64.tar.gz && \
+    tar xzf node-v4.2.6* && cd node-v4.2.6* && \
     mv bin/* /usr/local/bin/ && \
     mv lib/* /usr/local/lib/ && \
     mv include/* /usr/local/include/ && \
-    cd .. && rm -rf node-v4.2.4*
+    cd .. && rm -rf node-v4.2.6*
 WORKDIR /
 
 ADD test /tmp/test

--- a/v4.2.x/test/nodejs.bats
+++ b/v4.2.x/test/nodejs.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-@test "It should use Node v4.2.4" {
-  node -v | grep 4.2.4
+@test "It should use Node v4.2.6" {
+  node -v | grep 4.2.6
 }
 
 @test "It should install npm" {


### PR DESCRIPTION
Update node 4 to v4.2.6 (LTS)

Changelog: https://nodejs.org/en/blog/release/v4.2.6/
