### PR TITLE
Node 4.4.2 (LTS) update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Node.js on Docker.
 
 ## Available Tags
 
-* `v4.4.x`: Node.js v4.4.0
+* `v4.4.x`: Node.js v4.4.2
 * `v4.3.x`: Node.js v4.3.2
 * `v4.2.x`: Node.js v4.2.6
 * `v0.12.x`: Node.js v0.12.12

--- a/v4.4.x/Dockerfile
+++ b/v4.4.x/Dockerfile
@@ -1,12 +1,12 @@
 FROM quay.io/aptible/debian:wheezy
 
 WORKDIR /tmp
-RUN wget -q http://nodejs.org/dist/v4.4.0/node-v4.4.0-linux-x64.tar.gz && \
-    tar xzf node-v4.4.0* && cd node-v4.4.0* && \
+RUN wget -q http://nodejs.org/dist/v4.4.2/node-v4.4.2-linux-x64.tar.gz && \
+    tar xzf node-v4.4.2* && cd node-v4.4.2* && \
     mv bin/* /usr/local/bin/ && \
     mv lib/* /usr/local/lib/ && \
     mv include/* /usr/local/include/ && \
-    cd .. && rm -rf node-v4.4.0*
+    cd .. && rm -rf node-v4.4.2*
 WORKDIR /
 
 ADD test /tmp/test

--- a/v4.4.x/test/nodejs.bats
+++ b/v4.4.x/test/nodejs.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-@test "It should use Node v4.4.0" {
-  node -v | grep 4.4.0
+@test "It should use Node v4.4.2" {
+  node -v | grep 4.4.2
 }
 
 @test "It should install npm" {


### PR DESCRIPTION
This release includes a security update for npm. Release notes [here](http://nodejs.org/en/blog/release/v4.4.2/).
