### PR TITLE
Introduce support for node v6.3.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER = docker
-TAGS = v0.10.x v0.12.x v4.2.x v4.3.x v4.4.x v6.1.x v6.2.x
+TAGS = v0.10.x v0.12.x v4.2.x v4.3.x v4.4.x v6.1.x v6.2.x v6.3.x
 
 all: release
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Node.js on Docker.
 
 ## Available Tags
 
+* `v6.3.x`: Node.js v6.3.1
 * `v6.2.x`: Node.js v6.2.2
 * `v6.1.x`: Node.js v6.1.0
 * `v4.4.x`: Node.js v4.4.7

--- a/v6.3.x/Dockerfile
+++ b/v6.3.x/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/aptible/debian:wheezy
+
+WORKDIR /tmp
+RUN wget -q http://nodejs.org/dist/v6.3.1/node-v6.3.1-linux-x64.tar.gz && \
+    tar xzf node-v6.3.1* && cd node-v6.3.1* && \
+    mv bin/* /usr/local/bin/ && \
+    mv lib/* /usr/local/lib/ && \
+    mv include/* /usr/local/include/ && \
+    cd .. && rm -rf node-v6.3.1*
+WORKDIR /
+
+ADD test /tmp/test
+RUN bats /tmp/test

--- a/v6.3.x/test/nodejs.bats
+++ b/v6.3.x/test/nodejs.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "It should use Node v6.3.1" {
+  node -v | grep 6.3.1
+}
+
+@test "It should install npm" {
+  which npm
+}


### PR DESCRIPTION
Node v6.3.1 [release notes](https://nodejs.org/en/blog/release/v6.3.1/)
