### PR TITLE
Fix the EOL race between this and docker-debian.

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM quay.io/aptible/debian:wheezy
+FROM quay.io/aptible/debian:wheezy-eol
 
 ONBUILD RUN echo "All images based on Debian Wheezy are now deprecated. Please use the offical NodeJS Docker images instead.  See https://hub.docker.com/_/node/" && false
 


### PR DESCRIPTION
This should have been merged before docker-debian was - easy enough to fix.